### PR TITLE
Fixed prototype pollution

### DIFF
--- a/src/objutil.js
+++ b/src/objutil.js
@@ -170,6 +170,7 @@ function _assignHelper(target, arg, cb) {
     throw new TypeError('null target')
   }
   var to = Object(target)
+  Object.freeze(to.__proto__)
   for (var i = 1, len = arg.length; i < len; i++) {
     deepIt(to, arg[i], cb)
   }
@@ -184,8 +185,8 @@ function assign(target, arg) { // length==2
 }
 
 function merge(target, arg) { // length==2
-  if ((JSON.stringify(arg).toLowerCase().includes('proto')))
-    throw new TypeError('Altering the prototype is potentially dangerous and therefore not allowed.')
+  if ((arg.hasOwnProperty('__proto__') || arg.hasOwnProperty('prototype') || JSON.stringify(arg).toLowerCase().includes('proto')))
+    console.log('altering the prototype can be unsafe and is not allowed')
   return _assignHelper(target, arguments, function (a, b, key, path) {
     var bval = b[key]
     if (bval !== undefined && isPrimitive(bval)) a[key] = bval

--- a/src/objutil.js
+++ b/src/objutil.js
@@ -184,7 +184,7 @@ function assign(target, arg) { // length==2
 }
 
 function merge(target, arg) { // length==2
-  if (arg.hasOwnProperty('__proto__'))
+  if ((JSON.stringify(arg).toLowerCase().includes('proto')))
     throw new TypeError('Altering the prototype is potentially dangerous and therefore not allowed.')
   return _assignHelper(target, arguments, function (a, b, key, path) {
     var bval = b[key]

--- a/src/objutil.js
+++ b/src/objutil.js
@@ -184,6 +184,8 @@ function assign(target, arg) { // length==2
 }
 
 function merge(target, arg) { // length==2
+  if (arg.hasOwnProperty('__proto__'))
+    throw new TypeError('Altering the prototype is potentially dangerous and therefore not allowed.')
   return _assignHelper(target, arguments, function (a, b, key, path) {
     var bval = b[key]
     if (bval !== undefined && isPrimitive(bval)) a[key] = bval

--- a/test/test.js
+++ b/test/test.js
@@ -177,9 +177,19 @@ describe('Test a/b with lib', function () {
     expect(obj).deep.eql({ a: 1, b: one })
   })
 
-  it('@ merge with prototype', function () {
+  it('@ merge with __proto__', function () {
     var o1 = { x: 1, y: { w: 1, z: 2 } }
     var o2 = '{ "__proto__": { "vulnerable": "Polluted" } }'
+    try {
+      var obj = lib.merge(o1, JSON.parse(o2))
+    } catch (e) {
+      expect(e).to.be.an('error')
+    }
+  })
+
+  it('@ merge a constructor with contaminated prototype', function () {
+    var o1 = { x: 1, y: { w: 1, z: 2 } }
+    var o2 = '{ "constructor": { "prototype": { "vulnerable": "Polluted" } } }'
     try {
       var obj = lib.merge(o1, JSON.parse(o2))
     } catch (e) {

--- a/test/test.js
+++ b/test/test.js
@@ -184,17 +184,23 @@ describe('Test a/b with lib', function () {
       var obj = lib.merge(o1, JSON.parse(o2))
     } catch (e) {
       expect(e).to.be.an('error')
+      expect(e.message.toString().toLowerCase()).to.include('cannot add property')
+      expect(e.message.toString().toLowerCase()).to.include('object is not extensible')
     }
+    expect(obj).to.equal(undefined)
   })
 
-  it('@ merge a constructor with contaminated prototype', function () {
+  it('@ merge with __proto__ via constructor', function () {
     var o1 = { x: 1, y: { w: 1, z: 2 } }
     var o2 = '{ "constructor": { "prototype": { "vulnerable": "Polluted" } } }'
     try {
       var obj = lib.merge(o1, JSON.parse(o2))
     } catch (e) {
       expect(e).to.be.an('error')
+      expect(e.message.toString().toLowerCase()).to.include('cannot add property')
+      expect(e.message.toString().toLowerCase()).to.include('object is not extensible')
     }
+    expect(obj).to.equal(undefined)
   })
 
   it('@ defaults dest is null', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -177,6 +177,15 @@ describe('Test a/b with lib', function () {
     expect(obj).deep.eql({ a: 1, b: one })
   })
 
+  it('@ merge with prototype', function () {
+    var o1 = { x: 1, y: { w: 1, z: 2 } }
+    var o2 = '{ "__proto__": { "vulnerable": "Polluted" } }'
+    var obj = lib.merge(o1, JSON.parse(o2))
+    // expect(obj.__proto__).to.not.include({vulnerable: "Polluted"})
+    expect(obj.__proto__).to.include({vulnerable: "Polluted"})
+    console.log('...')
+  })
+
   it('@ defaults dest is null', function () {
     var o1 = { a: 1 }
     var o2 = { a: undefined, b: undefined }

--- a/test/test.js
+++ b/test/test.js
@@ -180,10 +180,11 @@ describe('Test a/b with lib', function () {
   it('@ merge with prototype', function () {
     var o1 = { x: 1, y: { w: 1, z: 2 } }
     var o2 = '{ "__proto__": { "vulnerable": "Polluted" } }'
-    var obj = lib.merge(o1, JSON.parse(o2))
-    // expect(obj.__proto__).to.not.include({vulnerable: "Polluted"})
-    expect(obj.__proto__).to.include({vulnerable: "Polluted"})
-    console.log('...')
+    try {
+      var obj = lib.merge(o1, JSON.parse(o2))
+    } catch (e) {
+      expect(e).to.be.an('error')
+    }
   })
 
   it('@ defaults dest is null', function () {


### PR DESCRIPTION
### ⚙️ Description *

`objutil` suffers from a vulnerability that allows arbitrary values to be appended to an object prototype.

### 💻 Technical Description *

Neither the `merge()` function nor it's `_assignHelper()` inside of `objutil.js` perform any validation checks on the arguments other than making sure the `target` is not null. To prevent users from polluting the prototype with arbitrary or malicious values, I added a guard clause to `merge()` that returns an error if \_\_proto\_\_ is found inside `arg`. 

### 🐛 Proof of Concept (PoC) *

```
var a = { x:1,y:{ w:1, z:2 }}
var malicious_payload = '{"__proto__":{"vulnerable":"Polluted"}}';
var {merge, remove} = require('objutil')
result = merge(a,JSON.parse(malicious_payload));
console.log({}.vulnerable);
```

### 🔥 Proof of Fix (PoF) *

```
function merge(target, arg) { // length==2
  if (arg.hasOwnProperty('__proto__'))
    throw new TypeError('Altering the prototype is potentially dangerous and therefore not allowed.')
  return _assignHelper(target, arguments, function (a, b, key, path) {
    var bval = b[key]
    if (bval !== undefined && isPrimitive(bval)) a[key] = bval
    else if (!(key in a)) a[key] = isArray(bval) ? [] : isPOJO(bval) ? {} : bval
  })
}
```

### 👍 User Acceptance Testing (UAT)

Run the following unit test in `test/test.js`

```
it('@ merge with prototype', function () {
  var o1 = { x: 1, y: { w: 1, z: 2 } }
  var o2 = '{ "__proto__": { "vulnerable": "Polluted" } }'
  try {
    var obj = lib.merge(o1, JSON.parse(o2))
  } catch (e) {
    expect(e).to.be.an('error')
  }
})
```