### PR TITLE
Fixed Prototype Pollution

### DIFF
--- a/src/objutil.js
+++ b/src/objutil.js
@@ -184,6 +184,8 @@ function assign(target, arg) { // length==2
 }
 
 function merge(target, arg) { // length==2
+  // freezing the prototype to prevent prototype pollution
+  Object.freeze(arg.prototype)
   return _assignHelper(target, arguments, function (a, b, key, path) {
     var bval = b[key]
     if (bval !== undefined && isPrimitive(bval)) a[key] = bval


### PR DESCRIPTION
### ⚙️ Description *

The fix is implemented by freezing the input `Object`'s `prototype`.

### 💻 Technical Description *

The function `merge()` function has 2 parameters `target` and `arg`. The `arg` parameter is being used to inject the prototype as per the PoC:

```javascript
var a = { x:1,y:{ w:1, z:2 }}
var malicious_payload = '{"__proto__":{"vulnerable":"Polluted"}}';
var {merge, remove} = require('objutil')
result = merge(a,JSON.parse(malicious_payload));
console.log({}.vulnerable);
```

These values (with the payload) is passed to the `merge()` function where it caused the prototype pollution, I used the `Object.freeze()` function to freeze the prototype just after accepting it which prevents further modification of the prototype.

**This fix is implemented with the help of this paper on Prototype Pollution:**

:spiral_notepad: [Prototype pollution attack in NodeJS application](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)

**From Mitigation Methods -> Freezing the prototype (from the paper):**
> The ECMAScript standard version 5 introduced a very interesting set of functionality to the
> JavaScript language. It allowed the definition of non-enumerable property, getter, setter and
> a lot more. One of API introduced was “Object.freeze”. When that function is called on an
> object, any further modification on that object will silently fail. Since the prototype of “Object”
> is an object, it’s possible to freeze it. Doing so will mitigate almost all the exploitable case.

### 🐛 Proof of Concept (PoC) *

```javascript
var a = { x:1,y:{ w:1, z:2 }}
var malicious_payload = '{"__proto__":{"vulnerable":"Polluted"}}';
var {merge, remove} = require('objutil')
result = merge(a,JSON.parse(malicious_payload));
console.log({}.vulnerable);
```

### 🔥 Proof of Fix (PoF) *

```javascript
function merge(target, arg) { // length==2
  // freezing the prototype to prevent prototype pollution
  Object.freeze(arg.prototype)
  return _assignHelper(target, arguments, function (a, b, key, path) {
    var bval = b[key]
    if (bval !== undefined && isPrimitive(bval)) a[key] = bval
    else if (!(key in a)) a[key] = isArray(bval) ? [] : isPOJO(bval) ? {} : bval
  })
}
```

`Object.freeze()` fixes this issue by not allowing modifications to the Object's prototype as mentioned above.

### 👍 User Acceptance Testing (UAT)

    $ node test/test.js

It doesn't introduce any breaking changes as the only further addition is an `Object.freeze()` function.

### 📊 Metadata *

#### Bounty URL:

https://www.huntr.dev/app/bounties/open/1-npm-objutil
